### PR TITLE
Bindings for FrodoKEM operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,41 +1,107 @@
 // main.go
-
 package main
 
 /*
 #cgo CFLAGS: -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -I/usr/include/
-#cgo LDFLAGS: -L/home/<SEULOCAL/projetos/Grupo_PQC/edital12PIBIC/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -L/usr/lib/ -lfrodo -lssl -lcrypto 
+#cgo LDFLAGS: -L/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -L/usr/lib/ -lfrodo -lssl -lcrypto 
 */
 import "C"
 
 import (
 	"fmt"
 	"log"
-	"zkpop-go/zkpop" // Make sure to import the package correctly
+	"bytes"
+	"zkpop-go/zkpop" 
 )
 
-func main() {
-	// Test KeyPair generation
-	fmt.Println("Generating keypair with zkpop...")
+//test FrodoKEM in N+1 iterations
+func testFrodoKEM(N int){
+        fmt.Println("Testing FrodoKEM...")
 
-//	pk, sk, zkpopProof, err := zkpop.KeyPair()
-	pk, sk, zkpopProof, err := zkpop.KeyPair()
+        //warmup
+        pk, sk, err := zkpop.KeyPairFrodo640()
+        if err != nil {
+                log.Fatalf("Error generating keypair: %v", err)
+        }
+
+        //test N keygens
+        for i := 0; i < N; i++  {
+                pk, sk, err = zkpop.KeyPairFrodo640()
+        }
+	
+	//warmup Encaps
+	ct, ss, err := zkpop.EncapsFrodo640(pk)
 	if err != nil {
-		log.Fatalf("Error generating keypair: %v", err)
+                log.Fatalf("Failed FrodoKEM encapsulation: %v", err)
+        }
+
+	//test N Encaps
+	for i := 0; i < N; i++  {
+                ct, ss, err = zkpop.EncapsFrodo640(pk)
+        }
+
+	//warmup Decaps
+	css, err := zkpop.DecapsFrodo640(ct, sk)
+	if err != nil || !bytes.Equal(ss,css) {
+                log.Fatalf("Failed FrodoKEM decapsulation.")
+        }
+
+	//test N Decaps
+	for i := 0; i < N; i++  {
+                css, err = zkpop.DecapsFrodo640(ct, sk)
+        }
+
+}
+
+
+//test FrodoKEM-NIZKPoP in N+1 iterations
+func testFrodoKEMNIZKPoP(N int){
+  	fmt.Println("Testing FrodoKEM-NIZKPoP...")
+
+	//warmup
+        pk, _, zkpopProof, err := zkpop.KeyPairFrodo640NIZKPoP()
+        if err != nil {
+                log.Fatalf("Error generating keypair: %v", err)
+        }
+
+	//test N keygens
+	for i := 0; i < N; i++  {
+        	pk, _, zkpopProof, err = zkpop.KeyPairFrodo640NIZKPoP()
 	}
 
-	fmt.Printf("Public Key: %x\n", pk)
-	fmt.Printf("Secret Key: %x\n", sk)
-	fmt.Printf("Zero-Knowledge Proof: %x\n", zkpopProof)
+        //fmt.Printf("Public Key: %x\n", pk)
+        //fmt.Printf("Secret Key: %x\n", sk)
+        //fmt.Printf("Zero-Knowledge Proof: %x\n", zkpopProof)
 
-	// Test zkpop verification
-	//fmt.Println("Verifying zkpop...")
+	//warmup
+	valid := zkpop.VerifyFrodo640ZKPop(pk, zkpopProof)
+        if !valid {
+                log.Fatalf("Error verifying ZKPoP: %v", err)
+	}
 
-	/*isValid := zkpop.VerifyZKPop(pk, zkpopProof) // Call zkpop.VerifyZKPop correctly
-	if isValid {
-		fmt.Println("zkpop verification successful!")
-	} else {
-		fmt.Println("zkpop verification failed.")
-	}*/
+	//test N verifications
+	for i := 0; i < N; i++  {
+		valid = zkpop.VerifyFrodo640ZKPop(pk, zkpopProof) 
+	}
+}
+
+//test FrodoKEM-NIZKPoP in N+1 iterations
+func testKyber(N int){
+	fmt.Println("Testing Kyber... Not implemented yet")
+}
+
+
+func main() {
+	N := 10
+	fmt.Printf("Testing %d iterations for each algorithm...\n", N)
+
+	//Frodo-KEM
+	testFrodoKEM(N)
+	testFrodoKEMNIZKPoP(N)
+
+	//TODO: Kyber
+	
+
+	fmt.Println("End of testing.")
 }
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 // main.go
+
 package main
 
 /*
-#cgo LDFLAGS: -L/usr/lib -lssl -lcrypto
+#cgo CFLAGS: -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -I/usr/include/
+#cgo LDFLAGS: -L/home/<SEULOCAL/projetos/Grupo_PQC/edital12PIBIC/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -L/usr/lib/ -lfrodo -lssl -lcrypto 
 */
 import "C"
 
@@ -16,6 +18,7 @@ func main() {
 	// Test KeyPair generation
 	fmt.Println("Generating keypair with zkpop...")
 
+//	pk, sk, zkpopProof, err := zkpop.KeyPair()
 	pk, sk, zkpopProof, err := zkpop.KeyPair()
 	if err != nil {
 		log.Fatalf("Error generating keypair: %v", err)
@@ -26,13 +29,13 @@ func main() {
 	fmt.Printf("Zero-Knowledge Proof: %x\n", zkpopProof)
 
 	// Test zkpop verification
-	fmt.Println("Verifying zkpop...")
+	//fmt.Println("Verifying zkpop...")
 
-	isValid := zkpop.VerifyZKPop(pk, zkpopProof) // Call zkpop.VerifyZKPop correctly
+	/*isValid := zkpop.VerifyZKPop(pk, zkpopProof) // Call zkpop.VerifyZKPop correctly
 	if isValid {
 		fmt.Println("zkpop verification successful!")
 	} else {
 		fmt.Println("zkpop verification failed.")
-	}
+	}*/
 }
 

--- a/zkpop/api_frodo640.h
+++ b/zkpop/api_frodo640.h
@@ -1,0 +1,29 @@
+/********************************************************************************************
+* FrodoKEM: Learning with Errors Key Encapsulation
+*
+* Abstract: parameters and API for FrodoKEM-640
+* https://github.com/Chair-for-Security-Engineering/KEM-NIZKPoP/blob/764abb34a7e1128c6f60114a7d2f9a6dd65fe3ce/frodo-zkpop/src/api_frodo640.h 
+*********************************************************************************************/
+
+#ifndef _API_Frodo640_H_
+#define _API_Frodo640_H_
+
+
+#define CRYPTO_SECRETKEYBYTES  19888     // sizeof(s) + CRYPTO_PUBLICKEYBYTES + 2*PARAMS_N*PARAMS_NBAR + BYTES_PKHASH
+#define CRYPTO_PUBLICKEYBYTES   9616     // sizeof(seed_A) + (PARAMS_LOGQ*PARAMS_N*PARAMS_NBAR)/8
+#define CRYPTO_BYTES              16
+#define CRYPTO_CIPHERTEXTBYTES  9720     // (PARAMS_LOGQ*PARAMS_N*PARAMS_NBAR)/8 + (PARAMS_LOGQ*PARAMS_NBAR*PARAMS_NBAR)/8
+
+// Algorithm name
+#define CRYPTO_ALGNAME "FrodoKEM-640"
+
+
+int crypto_kem_keypair_Frodo640(unsigned char *pk, unsigned char *sk);
+int crypto_kem_enc_Frodo640(unsigned char *ct, unsigned char *ss, const unsigned char *pk);
+int crypto_kem_dec_Frodo640(unsigned char *ss, const unsigned char *ct, const unsigned char *sk);
+
+int crypto_kem_keypair_nizkpop_Frodo640(unsigned char* pk, unsigned char* sk, unsigned char **zkpop, unsigned long *zkpop_size);
+int crypto_nizkpop_verify_Frodo640(const unsigned char *pk, const unsigned char *zkpop, unsigned long zkpop_size);
+
+
+#endif

--- a/zkpop/frodoKEM.go
+++ b/zkpop/frodoKEM.go
@@ -1,0 +1,63 @@
+// FrodoKEM original bindings, just for comparison purposes
+package zkpop
+
+/*
+#include "api_frodo640.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <openssl/evp.h> //from OpenSSL 1.1.1
+#include <openssl/aes.h>
+*/
+import "C"
+
+import (
+        "fmt"
+        "unsafe"
+)
+
+//binding for crypto_kem_keypair_Frodo640
+func KeyPairFrodo640()([]byte, []byte, error){
+	pk := make([]byte, C.CRYPTO_PUBLICKEYBYTES)
+        sk := make([]byte, C.CRYPTO_SECRETKEYBYTES)
+
+	ret := C.crypto_kem_keypair_Frodo640((*C.uint8_t)(unsafe.Pointer(&pk[0])),
+                (*C.uint8_t)(unsafe.Pointer(&sk[0])))
+
+	if ret != 0 {
+                return nil, nil, fmt.Errorf("failed to generate keypair")
+        }
+	return pk, sk, nil
+}
+
+//Encapsulation for a given public key pk
+//Returns a ciphertext ct and a 16-byte shared secret ss
+func EncapsFrodo640(pk []byte)([]byte, []byte, error){
+//	crypto_kem_enc_Frodo640
+//	(unsigned char *ct, unsigned char *ss, const unsigned char *pk)
+	ss := make([]byte, C.CRYPTO_BYTES)
+	ct := make([]byte, C.CRYPTO_CIPHERTEXTBYTES)
+
+	ret := C.crypto_kem_enc_Frodo640((*C.uint8_t)(unsafe.Pointer(&ct[0])),
+					   (*C.uint8_t)(unsafe.Pointer(&ss[0])),
+					   (*C.uint8_t)(unsafe.Pointer(&pk[0])))
+	if ret != 0 {
+                return nil, nil, fmt.Errorf("failed to encaps")
+        }
+        return ct, ss, nil
+}
+
+
+//Given a ciphertext ct and a private key sk
+//returns a candidate shared secret css
+func DecapsFrodo640(ct []byte, sk []byte)([]byte, error){
+	//crypto_kem_dec_Frodo640
+	css := make([]byte, C.CRYPTO_BYTES)
+
+        ret := C.crypto_kem_dec_Frodo640((*C.uint8_t)(unsafe.Pointer(&css[0])),
+                                           (*C.uint8_t)(unsafe.Pointer(&ct[0])),
+                                           (*C.uint8_t)(unsafe.Pointer(&sk[0])))
+        if ret != 0 {
+                return nil, fmt.Errorf("failed to perform decapsulation")
+        }
+        return css, nil
+}

--- a/zkpop/zkpop.go
+++ b/zkpop/zkpop.go
@@ -16,9 +16,9 @@ import (
 )
 
 
-//Frodo part
-func KeyPair() ([]byte, []byte, []byte, error) {
-        fmt.Println(C.CRYPTO_ALGNAME)
+//Frodo640-Keypair with NIZKPoP
+func KeyPairFrodo640NIZKPoP() ([]byte, []byte, []byte, error) {
+        //fmt.Println(C.CRYPTO_ALGNAME)
 	pk := make([]byte, C.CRYPTO_PUBLICKEYBYTES)
         sk := make([]byte, C.CRYPTO_SECRETKEYBYTES)
         var zkpop *C.uint8_t
@@ -38,35 +38,12 @@ func KeyPair() ([]byte, []byte, []byte, error) {
         return pk, sk, zkpopGo, nil
 }
 
-
-
-
-// KeyPair generates a keypair and proof of knowledge (zkpop).
-/*func KeyPair() ([]byte, []byte, []byte, error) {
-	pk := make([]byte, C.KYBER_INDCPA_PUBLICKEYBYTES)
-	sk := make([]byte, C.KYBER_INDCPA_SECRETKEYBYTES)
-	var zkpop *C.uint8_t
-	var zkpopSize C.size_t
-
-	ret := C.crypto_kem_keypair_nizkpop((*C.uint8_t)(unsafe.Pointer(&pk[0])),
-		(*C.uint8_t)(unsafe.Pointer(&sk[0])),
-		&zkpop, &zkpopSize)
-
-	if ret != 0 {
-		return nil, nil, nil, fmt.Errorf("failed to generate keypair")
-	}
-
-	zkpopGo := C.GoBytes(unsafe.Pointer(zkpop), C.int(zkpopSize))
-	C.free(unsafe.Pointer(zkpop)) // Free zkpop allocated in C
-
-	return pk, sk, zkpopGo, nil
+func VerifyFrodo640ZKPop(pk []byte, zkpop []byte) bool {
+        ret := C.crypto_nizkpop_verify_Frodo640((*C.uchar)(unsafe.Pointer(&pk[0])),
+                (*C.uchar)(unsafe.Pointer(&zkpop[0])),
+                C.ulong(len(zkpop))) //we could set a 'CRYPTO_NIZKPOPBYTES' in the .h API file...
+        return ret == 0
 }
 
-// VerifyZKPop verifies the proof of knowledge.
-func VerifyZKPop(pk []byte, zkpop []byte) bool {
-	ret := C.crypto_nizkpop_verify((*C.uchar)(unsafe.Pointer(&pk[0])),
-		(*C.uchar)(unsafe.Pointer(&zkpop[0])),
-		C.ulong(len(zkpop)))
-	return ret == 0
-}
-*/
+
+


### PR DESCRIPTION
This PR gives support to FrodoKEM (Keygen, Encaps, Decaps) and NIZK-PoP functions through go-bindings.

**Changes**

- `main.go` removes kyber functions and now includes FrodoKEM test functions (not from `testing` package, but this could be future work)
- `zkpop/zkpop.go` wraps functions from `api_frodo640.h` 
- `zkpop/frodoKEM.go` adds support to original FrodoKEM operations, for comparison.

**Limitations and Future Work**
- Only FrodoKEM-640 is supported; 
- `cgo LDFLAGS` and `CFLAGS` must be changed **before** building. This should be automatic
- We could do some profiling if using the `testing` package (future work).