### PR TITLE
Kyber512 zkpop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # zkpop-go
 
-`zkpop-go` is a Go wrapper around the `libzkpop` library from the
+`zkpop-go` is a Go wrapper around the 
 [KEM-NIZKPoP](https://github.com/Chair-for-Security-Engineering/KEM-NIZKPoP)
 project. It provides functions to generate keypairs, create Zero-Knowledge
 Proofs of Possession (ZKPoP), and verify proofs.
 
 ## Getting Started
+
+### Supported algorithms
+
+Currently, our binding supports functions like Keygen, Keygen-zkpop, Encaps, Decaps, and Verify-zkpop for:
+- Kyber512_avx2; and
+- FrodoKEM-640.
 
 ### Prerequisites
 
@@ -16,7 +22,6 @@ Ensure you have the following installed on your system:
   sudo apt install libssl-dev
   ```
 - Go programming language (version 1.15+ recommended).
-- CMake for building the external library.
 
 ### Clone the Repository
 
@@ -35,52 +40,54 @@ git submodule update --init --recursive
 
 ### Build the External Library
 
-The Go wrapper depends on the `libzkpop.a` static library, which needs to be
-built from the KEM-NIZKPoP project.
+1. Frodo-KEM
+To build the library, navigate to `external/KEM-NIZKPoP/frodo-zkpop/`:
 
-To build the library:
+`make clean && make OPT_LEVEL=FAST USE_OPENSSL=FALSE GENERATION_A=SHAKE128 ZKPOP_N=65536 ZKPOP_TAU=8 && frodo640/test_KEM`
 
-1. Navigate to the project root directory:
-   ```bash
-   cd zkpop-go
-   ```
-2. Run the following commands to create the build directory, configure the build, and compile the library:
-   ```bash
-   mkdir build
-   cd build
-   cmake ..
-   make
-   ```
+If you are going to use openssl, just do a `make` instead.
 
-This will generate `libzkpop.a` inside `build/lib/`.
+2. Kyber
+
+It was tricky to make the binding work for kyber; You will need to:
+
+- navigate to `/KEM-NIZKPoP/kyber-zkpop/avx2/` (In a hope that you have avx2 instructions!)
+- change the Makefile using some editor:
+```
+#Comment the rule libpqcrystals_kyber512_avx2.so (below)
+#libpqcrystals_kyber512_avx2.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+#        $(CC) -shared -fpic $(CFLAGS) -DKYBER_K=2 $(SOURCES) \
+#          symmetric-shake.c -o libpqcrystals_kyber512_avx2.so
+#and replace with
+libpqcrystals_kyber512_avx2.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+        $(CC) -shared -fpic $(CFLAGS) -Wl,--allow-multiple-definition -DKYBER_K=2 $(SOURCES) \
+          symmetric-shake.c zkpop.c zkpop.h  -o libpqcrystals_kyber512_avx2.so 
+
+```
+which actually do a export for zkpop symbols to kyber512_avx2.so library.
+- compile with `make shared`
+- It should generate a lot of `.so` files; you should copy them with `sudo cp *.so /usr/lib/`.
+- If you want, check with `nm -D libpqcrystals_kyber512_avx2.so` whether `pqcrystals_kyber512_avx2_crypto_kem_keypair_nizkpop` is actually there. If not, the change in the Makefile was not effective (maybe `make clean && make shared`  can help).
+
 
 ### Build the Go Project
 
-Once the library is built, you can compile the Go project and link it to the
-required libraries (OpenSSL and `libzkpop.a`):
+Before building the project, you need to change `main.go` because (sadly!) `CFLAGS` and `LDFLAGS` contains absolute paths. Change it to your path.
+
+Now you can build the project (navigate to `zkpop-go/` directory):
 
 ```bash
-CGO_CFLAGS="-mavx2 -maes -mbmi2 -O3 -I/usr/include/openssl" \
-CGO_LDFLAGS="-L/usr/lib/x86_64-linux-gnu -lssl -lcrypto" \
-go build -o zkpop
+go build -o zkpop`
 ```
 
-### Run the Test
-
-After building, you can run the main test file (`main.go`) to verify the
-implementation:
+### Execution
 
 ```bash
 ./zkpop
 ```
 
-### Notes
-- Ensure you have the appropriate AVX2, AES, and BMI2 support on your system’s
-  CPU.
-- Modify the OpenSSL paths in `CGO_CFLAGS` and `CGO_LDFLAGS` if your
-  installation differs.
-- The compilation still not fully complete and need further investigation to
-  include all necessary dependencies!
+it should execute 10 times for each Frodo640 and Kyber512 operations.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -92,3 +92,8 @@ it should execute 10 times for each Frodo640 and Kyber512 operations.
 ## License
 
 This project is licensed under the MIT License.
+
+
+## Contribution Guide
+
+TBD.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 // main.go
 package main
 
+
 /*
 #cgo CFLAGS: -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/kyber-zkpop/avx2/ -I/usr/include/ 
 #cgo LDFLAGS: -L/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -L/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/kyber-zkpop/avx2/ -L/usr/lib/ -lfrodo -lpqcrystals_kyber512_avx2 -lpqcrystals_aes256ctr_avx2 -lpqcrystals_fips202_ref -lpqcrystals_fips202x4_avx2 -lssl -lcrypto 
@@ -86,14 +87,31 @@ func testFrodoKEMNIZKPoP(N int){
 }
 
 //test Kyber512-NIZKPoP in N+1 iterations
-/*func testKyberNIZKPoP(N int){
+func testKyberNIZKPoP(N int){
+	fmt.Println("Testing Kyber512-NIZKPoP...")
 	//warmup
-        _, _, _, err := zkpop.KeyPairKyber512NIZKPoP()
+        pk, _, zkpopProof, err := zkpop.KeyPairKyber512NIZKPoP()
         if err != nil {
                 log.Fatalf("Error generating keypair: %v", err)
         }
 
-}*/
+	//test N keygens
+        for i := 0; i < N; i++  {
+                pk, _, zkpopProof, err = zkpop.KeyPairKyber512NIZKPoP()
+        }
+        //warmup
+        valid := zkpop.VerifyKyber512ZKPop(pk, zkpopProof)
+        if !valid {
+                log.Fatalf("Error verifying ZKPoP: %v", err)
+        }
+
+	//test N verifications
+        for i := 0; i < N; i++  {
+                valid = zkpop.VerifyKyber512ZKPop(pk, zkpopProof) 
+        }
+
+
+}
 
 func testKyber(N int){
 	fmt.Println("Testing Kyber...")
@@ -142,7 +160,7 @@ func main() {
 
 	//Kyber
 	testKyber(N)
-	//testKyberNIZKPoP(N)
+	testKyberNIZKPoP(N)
 
 	fmt.Println("End of testing.")
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@
 package main
 
 /*
-#cgo CFLAGS: -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -I/usr/include/
-#cgo LDFLAGS: -L/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -L/usr/lib/ -lfrodo -lssl -lcrypto 
+#cgo CFLAGS: -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -I/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/kyber-zkpop/avx2/ -I/usr/include/ 
+#cgo LDFLAGS: -L/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/frodo-zkpop/frodo640/ -L/home/<SEULOCAL>/zkpop-go/external/KEM-NIZKPoP/kyber-zkpop/avx2/ -L/usr/lib/ -lfrodo -lpqcrystals_kyber512_avx2 -lpqcrystals_aes256ctr_avx2 -lpqcrystals_fips202_ref -lpqcrystals_fips202x4_avx2 -lssl -lcrypto 
 */
 import "C"
 
@@ -85,9 +85,50 @@ func testFrodoKEMNIZKPoP(N int){
 	}
 }
 
-//test FrodoKEM-NIZKPoP in N+1 iterations
+//test Kyber512-NIZKPoP in N+1 iterations
+/*func testKyberNIZKPoP(N int){
+	//warmup
+        _, _, _, err := zkpop.KeyPairKyber512NIZKPoP()
+        if err != nil {
+                log.Fatalf("Error generating keypair: %v", err)
+        }
+
+}*/
+
 func testKyber(N int){
-	fmt.Println("Testing Kyber... Not implemented yet")
+	fmt.Println("Testing Kyber...")
+	 //warmup
+        pk, sk, err := zkpop.KeyPairKyber512()
+        if err != nil {
+                log.Fatalf("Error generating keypair: %v", err)
+        }
+
+	//test N keygens
+        for i := 0; i < N; i++  {
+                pk, sk, err = zkpop.KeyPairKyber512()
+        }
+
+        //warmup Encaps
+        ct, ss, err := zkpop.EncapsKyber512(pk)
+        if err != nil {
+                log.Fatalf("Failed Kyber512 encapsulation: %v", err)
+        }
+
+        //test N Encaps
+        for i := 0; i < N; i++  {
+                ct, ss, err = zkpop.EncapsKyber512(pk)
+        }
+
+	//warmup Decaps
+        css, err := zkpop.DecapsKyber512(ct, sk)
+        if err != nil || !bytes.Equal(ss,css) {
+                log.Fatalf("Failed Kyber512 decapsulation.")
+        }
+
+        //test N Decaps
+        for i := 0; i < N; i++  {
+                css, err = zkpop.DecapsKyber512(ct, sk)
+        }
 }
 
 
@@ -99,8 +140,9 @@ func main() {
 	testFrodoKEM(N)
 	testFrodoKEMNIZKPoP(N)
 
-	//TODO: Kyber
-	
+	//Kyber
+	testKyber(N)
+	//testKyberNIZKPoP(N)
 
 	fmt.Println("End of testing.")
 }

--- a/zkpop/kyber/aes256ctr.h
+++ b/zkpop/kyber/aes256ctr.h
@@ -1,0 +1,33 @@
+#ifndef AES256CTR_H
+#define AES256CTR_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <immintrin.h>
+
+#define AES256CTR_NAMESPACE(s) pqcrystals_kyber_aes256ctr_avx2_##s
+
+#define AES256CTR_BLOCKBYTES 64
+
+typedef struct {
+  __m128i rkeys[16];
+  __m128i n;
+} aes256ctr_ctx;
+
+#define aes256ctr_init AES256CTR_NAMESPACE(init)
+void aes256ctr_init(aes256ctr_ctx *state,
+                    const uint8_t key[32],
+                    uint64_t nonce);
+
+#define aes256ctr_squeezeblocks AES256CTR_NAMESPACE(squeezeblocks)
+void aes256ctr_squeezeblocks(uint8_t *out,
+                             size_t nblocks,
+                             aes256ctr_ctx *state);
+
+#define aes256ctr_prf AES256CTR_NAMESPACE(prf)
+void aes256ctr_prf(uint8_t *out,
+                   size_t outlen,
+                   const uint8_t key[32],
+                   uint64_t nonce);
+
+#endif

--- a/zkpop/kyber/align.h
+++ b/zkpop/kyber/align.h
@@ -1,0 +1,19 @@
+#ifndef ALIGN_H
+#define ALIGN_H
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define ALIGNED_UINT8(N)        \
+    union {                     \
+        uint8_t coeffs[N];      \
+        __m256i vec[(N+31)/32]; \
+    }
+
+#define ALIGNED_INT16(N)        \
+    union {                     \
+        int16_t coeffs[N];      \
+        __m256i vec[(N+15)/16]; \
+    }
+
+#endif

--- a/zkpop/kyber/api.h
+++ b/zkpop/kyber/api.h
@@ -1,0 +1,76 @@
+#ifndef API_H
+#define API_H
+
+#include <stdint.h>
+
+
+#define pqcrystals_kyber512_SECRETKEYBYTES 1632
+#define pqcrystals_kyber512_PUBLICKEYBYTES 800
+#define pqcrystals_kyber512_CIPHERTEXTBYTES 768
+#define pqcrystals_kyber512_BYTES 32
+
+#define pqcrystals_kyber512_avx2_SECRETKEYBYTES pqcrystals_kyber512_SECRETKEYBYTES
+#define pqcrystals_kyber512_avx2_PUBLICKEYBYTES pqcrystals_kyber512_PUBLICKEYBYTES
+#define pqcrystals_kyber512_avx2_CIPHERTEXTBYTES pqcrystals_kyber512_CIPHERTEXTBYTES
+#define pqcrystals_kyber512_avx2_BYTES pqcrystals_kyber512_BYTES
+
+int pqcrystals_kyber512_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber512_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber512_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber512_90s_avx2_SECRETKEYBYTES pqcrystals_kyber512_SECRETKEYBYTES
+#define pqcrystals_kyber512_90s_avx2_PUBLICKEYBYTES pqcrystals_kyber512_PUBLICKEYBYTES
+#define pqcrystals_kyber512_90s_avx2_CIPHERTEXTBYTES pqcrystals_kyber512_CIPHERTEXTBYTES
+#define pqcrystals_kyber512_90s_avx2_BYTES pqcrystals_kyber512_BYTES
+
+int pqcrystals_kyber512_90s_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber512_90s_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber512_90s_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber768_SECRETKEYBYTES 2400
+#define pqcrystals_kyber768_PUBLICKEYBYTES 1184
+#define pqcrystals_kyber768_CIPHERTEXTBYTES 1088
+#define pqcrystals_kyber768_BYTES 32
+
+#define pqcrystals_kyber768_avx2_SECRETKEYBYTES pqcrystals_kyber768_SECRETKEYBYTES
+#define pqcrystals_kyber768_avx2_PUBLICKEYBYTES pqcrystals_kyber768_PUBLICKEYBYTES
+#define pqcrystals_kyber768_avx2_CIPHERTEXTBYTES pqcrystals_kyber768_CIPHERTEXTBYTES
+#define pqcrystals_kyber768_avx2_BYTES pqcrystals_kyber768_BYTES
+
+int pqcrystals_kyber768_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber768_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber768_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber768_90s_avx2_SECRETKEYBYTES pqcrystals_kyber768_SECRETKEYBYTES
+#define pqcrystals_kyber768_90s_avx2_PUBLICKEYBYTES pqcrystals_kyber768_PUBLICKEYBYTES
+#define pqcrystals_kyber768_90s_avx2_CIPHERTEXTBYTES pqcrystals_kyber768_CIPHERTEXTBYTES
+#define pqcrystals_kyber768_90s_avx2_BYTES pqcrystals_kyber768_BYTES
+
+int pqcrystals_kyber768_90s_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber768_90s_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber768_90s_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber1024_SECRETKEYBYTES 3168
+#define pqcrystals_kyber1024_PUBLICKEYBYTES 1568
+#define pqcrystals_kyber1024_CIPHERTEXTBYTES 1568
+#define pqcrystals_kyber1024_BYTES 32
+
+#define pqcrystals_kyber1024_avx2_SECRETKEYBYTES pqcrystals_kyber1024_SECRETKEYBYTES
+#define pqcrystals_kyber1024_avx2_PUBLICKEYBYTES pqcrystals_kyber1024_PUBLICKEYBYTES
+#define pqcrystals_kyber1024_avx2_CIPHERTEXTBYTES pqcrystals_kyber1024_CIPHERTEXTBYTES
+#define pqcrystals_kyber1024_avx2_BYTES pqcrystals_kyber1024_BYTES
+
+int pqcrystals_kyber1024_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber1024_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber1024_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber1024_90s_avx2_SECRETKEYBYTES pqcrystals_kyber1024_SECRETKEYBYTES
+#define pqcrystals_kyber1024_90s_avx2_PUBLICKEYBYTES pqcrystals_kyber1024_PUBLICKEYBYTES
+#define pqcrystals_kyber1024_90s_avx2_CIPHERTEXTBYTES pqcrystals_kyber1024_CIPHERTEXTBYTES
+#define pqcrystals_kyber1024_90s_avx2_BYTES pqcrystals_kyber1024_BYTES
+
+int pqcrystals_kyber1024_90s_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber1024_90s_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber1024_90s_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#endif

--- a/zkpop/kyber/api_kyber.h
+++ b/zkpop/kyber/api_kyber.h
@@ -1,0 +1,75 @@
+#ifndef API_H
+#define API_H
+
+#include <stdint.h>
+
+#define pqcrystals_kyber512_SECRETKEYBYTES 1632
+#define pqcrystals_kyber512_PUBLICKEYBYTES 800
+#define pqcrystals_kyber512_CIPHERTEXTBYTES 768
+#define pqcrystals_kyber512_BYTES 32
+
+#define pqcrystals_kyber512_avx2_SECRETKEYBYTES pqcrystals_kyber512_SECRETKEYBYTES
+#define pqcrystals_kyber512_avx2_PUBLICKEYBYTES pqcrystals_kyber512_PUBLICKEYBYTES
+#define pqcrystals_kyber512_avx2_CIPHERTEXTBYTES pqcrystals_kyber512_CIPHERTEXTBYTES
+#define pqcrystals_kyber512_avx2_BYTES pqcrystals_kyber512_BYTES
+
+int pqcrystals_kyber512_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber512_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber512_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber512_90s_avx2_SECRETKEYBYTES pqcrystals_kyber512_SECRETKEYBYTES
+#define pqcrystals_kyber512_90s_avx2_PUBLICKEYBYTES pqcrystals_kyber512_PUBLICKEYBYTES
+#define pqcrystals_kyber512_90s_avx2_CIPHERTEXTBYTES pqcrystals_kyber512_CIPHERTEXTBYTES
+#define pqcrystals_kyber512_90s_avx2_BYTES pqcrystals_kyber512_BYTES
+
+int pqcrystals_kyber512_90s_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber512_90s_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber512_90s_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber768_SECRETKEYBYTES 2400
+#define pqcrystals_kyber768_PUBLICKEYBYTES 1184
+#define pqcrystals_kyber768_CIPHERTEXTBYTES 1088
+#define pqcrystals_kyber768_BYTES 32
+
+#define pqcrystals_kyber768_avx2_SECRETKEYBYTES pqcrystals_kyber768_SECRETKEYBYTES
+#define pqcrystals_kyber768_avx2_PUBLICKEYBYTES pqcrystals_kyber768_PUBLICKEYBYTES
+#define pqcrystals_kyber768_avx2_CIPHERTEXTBYTES pqcrystals_kyber768_CIPHERTEXTBYTES
+#define pqcrystals_kyber768_avx2_BYTES pqcrystals_kyber768_BYTES
+
+int pqcrystals_kyber768_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber768_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber768_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber768_90s_avx2_SECRETKEYBYTES pqcrystals_kyber768_SECRETKEYBYTES
+#define pqcrystals_kyber768_90s_avx2_PUBLICKEYBYTES pqcrystals_kyber768_PUBLICKEYBYTES
+#define pqcrystals_kyber768_90s_avx2_CIPHERTEXTBYTES pqcrystals_kyber768_CIPHERTEXTBYTES
+#define pqcrystals_kyber768_90s_avx2_BYTES pqcrystals_kyber768_BYTES
+
+int pqcrystals_kyber768_90s_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber768_90s_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber768_90s_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber1024_SECRETKEYBYTES 3168
+#define pqcrystals_kyber1024_PUBLICKEYBYTES 1568
+#define pqcrystals_kyber1024_CIPHERTEXTBYTES 1568
+#define pqcrystals_kyber1024_BYTES 32
+
+#define pqcrystals_kyber1024_avx2_SECRETKEYBYTES pqcrystals_kyber1024_SECRETKEYBYTES
+#define pqcrystals_kyber1024_avx2_PUBLICKEYBYTES pqcrystals_kyber1024_PUBLICKEYBYTES
+#define pqcrystals_kyber1024_avx2_CIPHERTEXTBYTES pqcrystals_kyber1024_CIPHERTEXTBYTES
+#define pqcrystals_kyber1024_avx2_BYTES pqcrystals_kyber1024_BYTES
+
+int pqcrystals_kyber1024_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber1024_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber1024_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#define pqcrystals_kyber1024_90s_avx2_SECRETKEYBYTES pqcrystals_kyber1024_SECRETKEYBYTES
+#define pqcrystals_kyber1024_90s_avx2_PUBLICKEYBYTES pqcrystals_kyber1024_PUBLICKEYBYTES
+#define pqcrystals_kyber1024_90s_avx2_CIPHERTEXTBYTES pqcrystals_kyber1024_CIPHERTEXTBYTES
+#define pqcrystals_kyber1024_90s_avx2_BYTES pqcrystals_kyber1024_BYTES
+
+int pqcrystals_kyber1024_90s_avx2_keypair(uint8_t *pk, uint8_t *sk);
+int pqcrystals_kyber1024_90s_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int pqcrystals_kyber1024_90s_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#endif

--- a/zkpop/kyber/api_kyber_zkpop.h
+++ b/zkpop/kyber/api_kyber_zkpop.h
@@ -1,0 +1,42 @@
+#ifndef ZKPOP__H
+#define ZKPOP__H
+
+#include <stdint.h>
+#include "params.h"
+#include "polyvec.h"
+
+
+//AAG: just alg name
+#define CRYPTO_KALGNAME "Kyber-NIZKPoP"
+
+
+#define LAZY 9
+
+typedef ALIGNED_INT16(ZKPOP_M) bundle_t;
+typedef ALIGNED_INT16(ZKPOP_M-ZKPOP_SIGMA) open_bundle_t;
+
+#if ZKPOP_N > 65536
+#error "Too many parties."
+#elif ZKPOP_N > 256
+typedef uint16_t party_t;
+#else 
+typedef uint8_t party_t;
+#endif
+
+#define crypto_kem_keypair_nizkpop KYBER_NAMESPACE(crypto_kem_keypair_nizkpop)
+int crypto_kem_keypair_nizkpop(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+                    uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES],
+                    uint8_t **zkpop,
+                    size_t *zkpop_size);
+
+#define crypto_nizkpop_verify KYBER_NAMESPACE(crypto_nizkpop_verify)
+int crypto_nizkpop_verify(const unsigned char *pk, const unsigned char *zkpop, unsigned long zkpop_size);
+
+
+void generate_S_E(polyvec *S, polyvec *E, const bundle_t *vk, const uint8_t audit_bundles[(ZKPOP_M+7)/8]);
+void generate_S_E_openbundle(polyvec *S, polyvec *E, open_bundle_t *openbundle, const bundle_t *vk, const uint8_t audit_bundles[(ZKPOP_M+7)/8]);
+void generate_seeds(uint8_t *seedtree);
+void sample_audit_parties (party_t audit_parties[ZKPOP_TAU], const uint8_t hB[KYBER_SYMBYTES]);
+void sample_audit_bundles (uint8_t audit_bundles[(ZKPOP_M+7)/8], const uint8_t h[KYBER_SYMBYTES]);
+
+#endif

--- a/zkpop/kyber/api_kyber_zkpop.h
+++ b/zkpop/kyber/api_kyber_zkpop.h
@@ -1,5 +1,5 @@
-#ifndef ZKPOP__H
-#define ZKPOP__H
+#ifndef API_KYBER_ZKPOP__H
+#define API_KYBER_ZKPOP__H
 
 #include <stdint.h>
 #include "params.h"

--- a/zkpop/kyber/cbd.h
+++ b/zkpop/kyber/cbd.h
@@ -1,0 +1,18 @@
+#ifndef CBD_H
+#define CBD_H
+
+#include <stdint.h>
+#include <immintrin.h>
+#include "params.h"
+#include "zkpop.h"
+#include "poly.h"
+
+#define poly_cbd_eta1 KYBER_NAMESPACE(poly_cbd_eta1)
+void poly_cbd_eta1(poly *r, const __m256i buf[KYBER_ETA1*KYBER_N/128+1]);
+
+#define poly_cbd_eta2 KYBER_NAMESPACE(poly_cbd_eta2)
+void poly_cbd_eta2(poly *r, const __m256i buf[KYBER_ETA2*KYBER_N/128]);
+
+void vec_cbd_eta1(bundle_t *r, const uint8_t seed[32]);
+
+#endif

--- a/zkpop/kyber/consts.h
+++ b/zkpop/kyber/consts.h
@@ -1,0 +1,46 @@
+#ifndef CONSTS_H
+#define CONSTS_H
+
+#include "params.h"
+
+#define _16XQ            0
+#define _16XQINV        16
+#define _16XV           32
+#define _16XFLO         48
+#define _16XFHI         64
+#define _16XMONTSQLO    80
+#define _16XMONTSQHI    96
+#define _16XMASK       112
+#define _REVIDXB       128
+#define _REVIDXD       144
+#define _ZETAS_EXP     160
+#define	_16XSHIFT      624
+#define _16XQHALF      640
+#define _16XETA1       656
+#define _16XMINUSETA1  672
+
+/* The C ABI on MacOS exports all symbols with a leading
+ * underscore. This means that any symbols we refer to from
+ * C files (functions) can't be found, and all symbols we
+ * refer to from ASM also can't be found.
+ *
+ * This define helps us get around this
+ */
+#ifdef __ASSEMBLER__
+#if defined(__WIN32__) || defined(__APPLE__)
+#define decorate(s) _##s
+#define cdecl2(s) decorate(s)
+#define cdecl(s) cdecl2(KYBER_NAMESPACE(##s))
+#else
+#define cdecl(s) KYBER_NAMESPACE(##s)
+#endif
+#endif
+
+#ifndef __ASSEMBLER__
+#include "align.h"
+typedef ALIGNED_INT16(688) qdata_t;
+#define qdata KYBER_NAMESPACE(qdata)
+extern const qdata_t qdata;
+#endif
+
+#endif

--- a/zkpop/kyber/cpucycles.h
+++ b/zkpop/kyber/cpucycles.h
@@ -1,0 +1,33 @@
+#ifndef CPUCYCLES_H
+#define CPUCYCLES_H
+
+#include <stdint.h>
+
+#ifdef USE_RDPMC  /* Needs echo 2 > /sys/devices/cpu/rdpmc */
+
+static inline uint64_t cpucycles(void) {
+  const uint32_t ecx = (1U << 30) + 1;
+  uint64_t result;
+
+  __asm__ volatile ("rdpmc; shlq $32,%%rdx; orq %%rdx,%%rax"
+    : "=a" (result) : "c" (ecx) : "rdx");
+
+  return result;
+}
+
+#else
+
+static inline uint64_t cpucycles(void) {
+  uint64_t result;
+
+  __asm__ volatile ("rdtsc; shlq $32,%%rdx; orq %%rdx,%%rax"
+    : "=a" (result) : : "%rdx");
+
+  return result;
+}
+
+#endif
+
+uint64_t cpucycles_overhead(void);
+
+#endif

--- a/zkpop/kyber/fips202.h
+++ b/zkpop/kyber/fips202.h
@@ -1,0 +1,54 @@
+#ifndef FIPS202_H
+#define FIPS202_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHAKE128_RATE 168
+#define SHAKE256_RATE 136
+#define SHA3_256_RATE 136
+#define SHA3_512_RATE 72
+
+#define FIPS202_NAMESPACE(s) pqcrystals_kyber_fips202_avx2_##s
+
+typedef struct {
+    uint64_t s[25];
+    unsigned int pos;
+} keccak_state;
+
+#define shake128_init FIPS202_NAMESPACE(shake128_init)
+void shake128_init(keccak_state *state);
+#define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
+void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_finalize FIPS202_NAMESPACE(shake128_finalize)
+void shake128_finalize(keccak_state *state);
+#define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
+void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake128_absorb_once FIPS202_NAMESPACE(shake128_absorb_once)
+void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
+void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
+
+#define shake256_init FIPS202_NAMESPACE(shake256_init)
+void shake256_init(keccak_state *state);
+#define shake256_absorb FIPS202_NAMESPACE(shake256_absorb)
+void shake256_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_finalize FIPS202_NAMESPACE(shake256_finalize)
+void shake256_finalize(keccak_state *state);
+#define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)
+void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake256_absorb_once FIPS202_NAMESPACE(shake256_absorb_once)
+void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
+void shake256_squeezeblocks(uint8_t *out, size_t nblocks,  keccak_state *state);
+
+#define shake128 FIPS202_NAMESPACE(shake128)
+void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define shake256 FIPS202_NAMESPACE(shake256)
+void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define sha3_256 FIPS202_NAMESPACE(sha3_256)
+void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen);
+#define sha3_512 FIPS202_NAMESPACE(sha3_512)
+void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen);
+
+#endif

--- a/zkpop/kyber/fips202x4.h
+++ b/zkpop/kyber/fips202x4.h
@@ -1,0 +1,70 @@
+#ifndef FIPS202X4_H
+#define FIPS202X4_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <immintrin.h>
+
+#define FIPS202X4_NAMESPACE(s) pqcrystals_kyber_fips202x4_avx2_##s
+
+typedef struct {
+  __m256i s[25];
+} keccakx4_state;
+
+#define shake128x4_absorb_once FIPS202X4_NAMESPACE(shake128x4_absorb_once)
+void shake128x4_absorb_once(keccakx4_state *state,
+                            const uint8_t *in0,
+                            const uint8_t *in1,
+                            const uint8_t *in2,
+                            const uint8_t *in3,
+                            size_t inlen);
+
+#define shake128x4_squeezeblocks FIPS202X4_NAMESPACE(shake128x4_squeezeblocks)
+void shake128x4_squeezeblocks(uint8_t *out0,
+                              uint8_t *out1,
+                              uint8_t *out2,
+                              uint8_t *out3,
+                              size_t nblocks,
+                              keccakx4_state *state);
+
+#define shake256x4_absorb_once FIPS202X4_NAMESPACE(shake256x4_absorb_once)
+void shake256x4_absorb_once(keccakx4_state *state,
+                            const uint8_t *in0,
+                            const uint8_t *in1,
+                            const uint8_t *in2,
+                            const uint8_t *in3,
+                            size_t inlen);
+
+#define shake256x4_squeezeblocks FIPS202X4_NAMESPACE(shake256x4_squeezeblocks)
+void shake256x4_squeezeblocks(uint8_t *out0,
+                              uint8_t *out1,
+                              uint8_t *out2,
+                              uint8_t *out3,
+                              size_t nblocks,
+                              keccakx4_state *state);
+
+#define shake128x4 FIPS202X4_NAMESPACE(shake128x4)
+void shake128x4(uint8_t *out0,
+                uint8_t *out1,
+                uint8_t *out2,
+                uint8_t *out3,
+                size_t outlen,
+                const uint8_t *in0,
+                const uint8_t *in1,
+                const uint8_t *in2,
+                const uint8_t *in3,
+                size_t inlen);
+
+#define shake256x4 FIPS202X4_NAMESPACE(shake256x4)
+void shake256x4(uint8_t *out0,
+                uint8_t *out1,
+                uint8_t *out2,
+                uint8_t *out3,
+                size_t outlen,
+                const uint8_t *in0,
+                const uint8_t *in1,
+                const uint8_t *in2,
+                const uint8_t *in3,
+                size_t inlen);
+
+#endif

--- a/zkpop/kyber/indcpa.h
+++ b/zkpop/kyber/indcpa.h
@@ -1,0 +1,26 @@
+#ifndef INDCPA_H
+#define INDCPA_H
+
+#include <stdint.h>
+#include "params.h"
+#include "polyvec.h"
+
+#define gen_matrix KYBER_NAMESPACE(gen_matrix)
+void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed);
+
+#define indcpa_keypair KYBER_NAMESPACE(indcpa_keypair)
+void indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+                    uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]);
+
+#define indcpa_enc KYBER_NAMESPACE(indcpa_enc)
+void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
+                const uint8_t m[KYBER_INDCPA_MSGBYTES],
+                const uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+                const uint8_t coins[KYBER_SYMBYTES]);
+
+#define indcpa_dec KYBER_NAMESPACE(indcpa_dec)
+void indcpa_dec(uint8_t m[KYBER_INDCPA_MSGBYTES],
+                const uint8_t c[KYBER_INDCPA_BYTES],
+                const uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]);
+
+#endif

--- a/zkpop/kyber/kem.h
+++ b/zkpop/kyber/kem.h
@@ -1,0 +1,42 @@
+#ifndef KEM_H
+#define KEM_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "params.h"
+
+#define CRYPTO_SECRETKEYBYTES  KYBER_SECRETKEYBYTES
+#define CRYPTO_PUBLICKEYBYTES  KYBER_PUBLICKEYBYTES
+#define CRYPTO_CIPHERTEXTBYTES KYBER_CIPHERTEXTBYTES
+#define CRYPTO_BYTES           KYBER_SSBYTES
+
+#if   (KYBER_K == 2)
+#ifdef KYBER_90S
+#define CRYPTO_ALGNAME "Kyber512-90s"
+#else
+#define CRYPTO_ALGNAME "Kyber512"
+#endif
+#elif (KYBER_K == 3)
+#ifdef KYBER_90S
+#define CRYPTO_ALGNAME "Kyber768-90s"
+#else
+#define CRYPTO_ALGNAME "Kyber768"
+#endif
+#elif (KYBER_K == 4)
+#ifdef KYBER_90S
+#define CRYPTO_ALGNAME "Kyber1024-90s"
+#else
+#define CRYPTO_ALGNAME "Kyber1024"
+#endif
+#endif
+
+#define crypto_kem_keypair KYBER_NAMESPACE(keypair)
+int crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
+
+#define crypto_kem_enc KYBER_NAMESPACE(enc)
+int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+
+#define crypto_kem_dec KYBER_NAMESPACE(dec)
+int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#endif

--- a/zkpop/kyber/kex.h
+++ b/zkpop/kyber/kex.h
@@ -1,0 +1,26 @@
+#ifndef KEX_H
+#define KEX_H
+
+#include <stdint.h>
+#include "params.h"
+
+#define KEX_UAKE_SENDABYTES (KYBER_PUBLICKEYBYTES + KYBER_CIPHERTEXTBYTES)
+#define KEX_UAKE_SENDBBYTES (KYBER_CIPHERTEXTBYTES)
+
+#define KEX_AKE_SENDABYTES (KYBER_PUBLICKEYBYTES + KYBER_CIPHERTEXTBYTES)
+#define KEX_AKE_SENDBBYTES (2*KYBER_CIPHERTEXTBYTES)
+
+#define KEX_SSBYTES KYBER_SSBYTES
+
+void kex_uake_initA(uint8_t *send, uint8_t *tk, uint8_t *sk, const uint8_t *pkb);
+
+void kex_uake_sharedB(uint8_t *send, uint8_t *k, const uint8_t *recv, const uint8_t *skb);
+
+void kex_uake_sharedA(uint8_t *k, const uint8_t *recv, const uint8_t *tk, const uint8_t *sk);
+
+void kex_ake_initA(uint8_t *send, uint8_t *tk, uint8_t *sk, const uint8_t *pkb);
+void kex_ake_sharedB(uint8_t *send, uint8_t *k, const uint8_t *recv, const uint8_t *skb, const uint8_t *pka);
+
+void kex_ake_sharedA(uint8_t *k, const uint8_t *recv, const uint8_t *tk, const uint8_t *sk, const uint8_t *ska);
+
+#endif

--- a/zkpop/kyber/log.h
+++ b/zkpop/kyber/log.h
@@ -1,0 +1,10 @@
+#ifndef LOG__H
+#define LOG__H
+
+#define LOG_1(n) (((n) >= 2) ? 1 : 0)
+#define LOG_2(n) (((n) >= 1<<2) ? (2 + LOG_1((n)>>2)) : LOG_1(n))
+#define LOG_4(n) (((n) >= 1<<4) ? (4 + LOG_2((n)>>4)) : LOG_2(n))
+#define LOG_8(n) (((n) >= 1<<8) ? (8 + LOG_4((n)>>8)) : LOG_4(n))
+#define LOG(n)   (((n) >= 1<<16) ? (16 + LOG_8((n)>>16)) : LOG_8(n))
+
+#endif

--- a/zkpop/kyber/ntt.h
+++ b/zkpop/kyber/ntt.h
@@ -1,0 +1,28 @@
+#ifndef NTT_H
+#define NTT_H
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define ntt_avx KYBER_NAMESPACE(ntt_avx)
+void ntt_avx(__m256i *r, const __m256i *qdata);
+#define invntt_avx KYBER_NAMESPACE(invntt_avx)
+void invntt_avx(__m256i *r, const __m256i *qdata);
+
+#define nttpack_avx KYBER_NAMESPACE(nttpack_avx)
+void nttpack_avx(__m256i *r, const __m256i *qdata);
+#define nttunpack_avx KYBER_NAMESPACE(nttunpack_avx)
+void nttunpack_avx(__m256i *r, const __m256i *qdata);
+
+#define basemul_avx KYBER_NAMESPACE(basemul_avx)
+void basemul_avx(__m256i *r,
+                 const __m256i *a,
+                 const __m256i *b,
+                 const __m256i *qdata);
+
+#define ntttobytes_avx KYBER_NAMESPACE(ntttobytes_avx)
+void ntttobytes_avx(uint8_t *r, const __m256i *a, const __m256i *qdata);
+#define nttfrombytes_avx KYBER_NAMESPACE(nttfrombytes_avx)
+void nttfrombytes_avx(__m256i *r, const uint8_t *a, const __m256i *qdata);
+
+#endif

--- a/zkpop/kyber/params.h
+++ b/zkpop/kyber/params.h
@@ -1,0 +1,100 @@
+#ifndef PARAMS_H
+#define PARAMS_H
+
+#include "log.h"
+
+#ifndef KYBER_K
+#define KYBER_K 2	/* Change this for different security strengths */
+#endif
+
+//#define KYBER_90S	/* Uncomment this if you want the 90S variant */
+
+/* Don't change parameters below this line */
+#if   (KYBER_K == 2)
+#ifdef KYBER_90S
+#define KYBER_NAMESPACE(s) pqcrystals_kyber512_90s_avx2_##s
+#else
+#define KYBER_NAMESPACE(s) pqcrystals_kyber512_avx2_##s
+#endif
+#elif (KYBER_K == 3)
+#ifdef KYBER_90S
+#define KYBER_NAMESPACE(s) pqcrystals_kyber768_90s_avx2_##s
+#else
+#define KYBER_NAMESPACE(s) pqcrystals_kyber768_avx2_##s
+#endif
+#elif (KYBER_K == 4)
+#ifdef KYBER_90S
+#define KYBER_NAMESPACE(s) pqcrystals_kyber1024_90s_avx2_##s
+#else
+#define KYBER_NAMESPACE(s) pqcrystals_kyber1024_avx2_##s
+#endif
+#else
+#error "KYBER_K must be in {2,3,4}"
+#endif
+
+#define KYBER_N 256
+#define KYBER_Q 3329
+
+#define KYBER_SYMBYTES 32   /* size in bytes of hashes, and seeds */
+#define KYBER_SSBYTES  32   /* size in bytes of shared key */
+
+#define KYBER_POLYBYTES		384
+#define KYBER_POLYVECBYTES	(KYBER_K * KYBER_POLYBYTES)
+
+#if KYBER_K == 2
+#define KYBER_ETA1 3
+#define KYBER_POLYCOMPRESSEDBYTES    128
+#define KYBER_POLYVECCOMPRESSEDBYTES (KYBER_K * 320)
+#define ZKPOP_M 1280
+#define ZKPOP_SYMBYTES 32
+#ifndef ZKPOP_N
+#define ZKPOP_N 4
+#endif
+#ifndef ZKPOP_TAU
+#define ZKPOP_TAU 64
+#endif
+#elif KYBER_K == 3
+#define KYBER_ETA1 2
+#define KYBER_POLYCOMPRESSEDBYTES    128
+#define KYBER_POLYVECCOMPRESSEDBYTES (KYBER_K * 320)
+#define ZKPOP_M 1870
+#define ZKPOP_SYMBYTES 48
+#ifndef ZKPOP_N
+#define ZKPOP_N 4
+#endif
+#ifndef ZKPOP_TAU
+#define ZKPOP_TAU 96
+#endif
+#elif KYBER_K == 4
+#define KYBER_ETA1 2
+#define KYBER_POLYCOMPRESSEDBYTES    160
+#define KYBER_POLYVECCOMPRESSEDBYTES (KYBER_K * 352)
+#define ZKPOP_M 2493
+#define ZKPOP_SYMBYTES 64
+#ifndef ZKPOP_N
+#define ZKPOP_N 4
+#endif
+#ifndef ZKPOP_TAU
+#define ZKPOP_TAU 128
+#endif
+#endif
+
+#define ZKPOP_SIGMA (KYBER_K * KYBER_N * 2)
+#define ZKPOP_M_PACKEDBYTES ((ZKPOP_M/KYBER_N)*KYBER_POLYBYTES + sizeof(int16_t)*(ZKPOP_M%KYBER_N))
+#define ZKPOP_M_SIGMA_PACKEDBYTES (((ZKPOP_M-ZKPOP_SIGMA)/KYBER_N)*KYBER_POLYBYTES + sizeof(int16_t)*((ZKPOP_M-ZKPOP_SIGMA)%KYBER_N))
+
+#define KYBER_ZKPOP_MAXBYTES (ZKPOP_SYMBYTES * (3 + ZKPOP_TAU * (LOG(ZKPOP_N) + 2)) + ZKPOP_M_PACKEDBYTES * ZKPOP_TAU + ZKPOP_M_SIGMA_PACKEDBYTES)
+
+#define KYBER_ETA2 2
+
+#define KYBER_INDCPA_MSGBYTES       (KYBER_SYMBYTES)
+#define KYBER_INDCPA_PUBLICKEYBYTES (KYBER_POLYVECBYTES + KYBER_SYMBYTES)
+#define KYBER_INDCPA_SECRETKEYBYTES (KYBER_POLYVECBYTES)
+#define KYBER_INDCPA_BYTES          (KYBER_POLYVECCOMPRESSEDBYTES + KYBER_POLYCOMPRESSEDBYTES)
+
+#define KYBER_PUBLICKEYBYTES  (KYBER_INDCPA_PUBLICKEYBYTES)
+/* 32 bytes of additional space to save H(pk) */
+#define KYBER_SECRETKEYBYTES  (KYBER_INDCPA_SECRETKEYBYTES + KYBER_INDCPA_PUBLICKEYBYTES + 2*KYBER_SYMBYTES)
+#define KYBER_CIPHERTEXTBYTES (KYBER_INDCPA_BYTES)
+
+#endif

--- a/zkpop/kyber/poly.h
+++ b/zkpop/kyber/poly.h
@@ -1,0 +1,77 @@
+#ifndef POLY_H
+#define POLY_H
+
+#include <stdint.h>
+#include "align.h"
+#include "params.h"
+
+typedef ALIGNED_INT16(KYBER_N) poly;
+
+#define poly_compress KYBER_NAMESPACE(poly_compress)
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a);
+#define poly_decompress KYBER_NAMESPACE(poly_decompress)
+void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES]);
+
+#define poly_tobytes KYBER_NAMESPACE(poly_tobytes)
+void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a);
+#define poly_frombytes KYBER_NAMESPACE(poly_frombytes)
+void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]);
+
+#define poly_frommsg KYBER_NAMESPACE(poly_frommsg)
+void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES]);
+#define poly_tomsg KYBER_NAMESPACE(poly_tomsg)
+void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *r);
+
+#define poly_getnoise_eta1 KYBER_NAMESPACE(poly_getnoise_eta1)
+void poly_getnoise_eta1(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce);
+
+#define poly_getnoise_eta2 KYBER_NAMESPACE(poly_getnoise_eta2)
+void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce);
+
+#ifndef KYBER_90S
+#define poly_getnoise_eta1_4x KYBER_NAMESPACE(poly_getnoise_eta2_4x)
+void poly_getnoise_eta1_4x(poly *r0,
+                           poly *r1,
+                           poly *r2,
+                           poly *r3,
+                           const uint8_t *seed,
+                           uint8_t nonce0,
+                           uint8_t nonce1,
+                           uint8_t nonce2,
+                           uint8_t nonce3);
+
+#if KYBER_K == 2
+#define poly_getnoise_eta1122_4x KYBER_NAMESPACE(poly_getnoise_eta1122_4x)
+void poly_getnoise_eta1122_4x(poly *r0,
+                              poly *r1,
+                              poly *r2,
+                              poly *r3,
+                              const uint8_t *seed,
+                              uint8_t nonce0,
+                              uint8_t nonce1,
+                              uint8_t nonce2,
+                              uint8_t nonce3);
+#endif
+#endif
+
+
+#define poly_ntt KYBER_NAMESPACE(poly_ntt)
+void poly_ntt(poly *r);
+#define poly_invntt_tomont KYBER_NAMESPACE(poly_invntt_tomont)
+void poly_invntt_tomont(poly *r);
+#define poly_nttunpack KYBER_NAMESPACE(poly_nttunpack)
+void poly_nttunpack(poly *r);
+#define poly_basemul_montgomery KYBER_NAMESPACE(poly_basemul_montgomery)
+void poly_basemul_montgomery(poly *r, const poly *a, const poly *b);
+#define poly_tomont KYBER_NAMESPACE(poly_tomont)
+void poly_tomont(poly *r);
+
+#define poly_reduce KYBER_NAMESPACE(poly_reduce)
+void poly_reduce(poly *r);
+
+#define poly_add KYBER_NAMESPACE(poly_add)
+void poly_add(poly *r, const poly *a, const poly *b);
+#define poly_sub KYBER_NAMESPACE(poly_sub)
+void poly_sub(poly *r, const poly *a, const poly *b);
+
+#endif

--- a/zkpop/kyber/polyvec.h
+++ b/zkpop/kyber/polyvec.h
@@ -1,0 +1,36 @@
+#ifndef POLYVEC_H
+#define POLYVEC_H
+
+#include <stdint.h>
+#include "params.h"
+#include "poly.h"
+
+typedef struct{
+  poly vec[KYBER_K];
+} polyvec;
+
+#define polyvec_compress KYBER_NAMESPACE(polyvec_compress)
+void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES+2], const polyvec *a);
+#define polyvec_decompress KYBER_NAMESPACE(polyvec_decompress)
+void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES+12]);
+
+#define polyvec_tobytes KYBER_NAMESPACE(polyvec_tobytes)
+void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a);
+#define polyvec_frombytes KYBER_NAMESPACE(polyvec_frombytes)
+void polyvec_frombytes(polyvec *r, const uint8_t a[KYBER_POLYVECBYTES]);
+
+#define polyvec_ntt KYBER_NAMESPACE(polyvec_ntt)
+void polyvec_ntt(polyvec *r);
+#define polyvec_invntt_tomont KYBER_NAMESPACE(polyvec_invntt_tomont)
+void polyvec_invntt_tomont(polyvec *r);
+
+#define polyvec_basemul_acc_montgomery KYBER_NAMESPACE(polyvec_basemul_acc_montgomery)
+void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b);
+
+#define polyvec_reduce KYBER_NAMESPACE(polyvec_reduce)
+void polyvec_reduce(polyvec *r);
+
+#define polyvec_add KYBER_NAMESPACE(polyvec_add)
+void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b);
+
+#endif

--- a/zkpop/kyber/randombytes.h
+++ b/zkpop/kyber/randombytes.h
@@ -1,0 +1,9 @@
+#ifndef RANDOMBYTES_H
+#define RANDOMBYTES_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void randombytes(uint8_t *out, size_t outlen);
+
+#endif

--- a/zkpop/kyber/reduce.h
+++ b/zkpop/kyber/reduce.h
@@ -1,0 +1,14 @@
+#ifndef REDUCE_H
+#define REDUCE_H
+
+#include "params.h"
+#include <immintrin.h>
+
+#define reduce_avx KYBER_NAMESPACE(reduce_avx)
+void reduce_avx(__m256i *r, const __m256i *qdata);
+#define reduce16_avx KYBER_NAMESPACE(reduce16_avx)
+void reduce16_avx(__m256i *r, const __m256i *qdata);
+#define tomont_avx KYBER_NAMESPACE(tomont_avx)
+void tomont_avx(__m256i *r, const __m256i *qdata);
+
+#endif

--- a/zkpop/kyber/rejsample.h
+++ b/zkpop/kyber/rejsample.h
@@ -1,0 +1,17 @@
+#ifndef REJSAMPLE_H
+#define REJSAMPLE_H
+
+#include <stdint.h>
+#include "params.h"
+#include "symmetric.h"
+
+#define REJ_UNIFORM_AVX_NBLOCKS ((12*KYBER_N/8*(1 << 12)/KYBER_Q + XOF_BLOCKBYTES)/XOF_BLOCKBYTES)
+#define REJ_UNIFORM_AVX_BUFLEN (REJ_UNIFORM_AVX_NBLOCKS*XOF_BLOCKBYTES)
+
+#define rej_uniform_avx KYBER_NAMESPACE(rej_uniform_avx)
+unsigned int rej_uniform_avx(int16_t *r, const uint8_t *buf);
+
+#define rej_uniform_avx_len KYBER_NAMESPACE(rej_uniform_avx_len)
+unsigned int rej_uniform_avx_len(int16_t * restrict r, size_t num, const uint8_t *buf, size_t size);
+
+#endif

--- a/zkpop/kyber/rng.h
+++ b/zkpop/kyber/rng.h
@@ -1,0 +1,55 @@
+//
+//  rng.h
+//
+//  Created by Bassham, Lawrence E (Fed) on 8/29/17.
+//  Copyright © 2017 Bassham, Lawrence E (Fed). All rights reserved.
+//
+
+#ifndef rng_h
+#define rng_h
+
+#include <stdio.h>
+
+#define RNG_SUCCESS      0
+#define RNG_BAD_MAXLEN  -1
+#define RNG_BAD_OUTBUF  -2
+#define RNG_BAD_REQ_LEN -3
+
+typedef struct {
+    unsigned char   buffer[16];
+    int             buffer_pos;
+    unsigned long   length_remaining;
+    unsigned char   key[32];
+    unsigned char   ctr[16];
+} AES_XOF_struct;
+
+typedef struct {
+    unsigned char   Key[32];
+    unsigned char   V[16];
+    int             reseed_counter;
+} AES256_CTR_DRBG_struct;
+
+
+void
+AES256_CTR_DRBG_Update(unsigned char *provided_data,
+                       unsigned char *Key,
+                       unsigned char *V);
+
+int
+seedexpander_init(AES_XOF_struct *ctx,
+                  unsigned char *seed,
+                  unsigned char *diversifier,
+                  unsigned long maxlen);
+
+int
+seedexpander(AES_XOF_struct *ctx, unsigned char *x, unsigned long xlen);
+
+void
+randombytes_init(unsigned char *entropy_input,
+                 unsigned char *personalization_string,
+                 int security_strength);
+
+int
+randombytes(unsigned char *x, unsigned long long xlen);
+
+#endif /* rng_h */

--- a/zkpop/kyber/sha2.h
+++ b/zkpop/kyber/sha2.h
@@ -1,0 +1,9 @@
+#ifndef SHA_2_H
+#define SHA_2_H
+
+#include <openssl/sha.h>
+
+#define sha256(OUT, IN, INBYTES) SHA256(IN, INBYTES, OUT)
+#define sha512(OUT, IN, INBYTES) SHA512(IN, INBYTES, OUT)
+
+#endif

--- a/zkpop/kyber/speed_print.h
+++ b/zkpop/kyber/speed_print.h
@@ -1,0 +1,10 @@
+#ifndef PRINT_SPEED_H
+#define PRINT_SPEED_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void print_results(const char *s, uint64_t *t, size_t tlen);
+void print_size_results(const char *s, uint64_t *t, size_t tlen);
+
+#endif

--- a/zkpop/kyber/symmetric.h
+++ b/zkpop/kyber/symmetric.h
@@ -1,0 +1,63 @@
+#ifndef SYMMETRIC_H
+#define SYMMETRIC_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "params.h"
+
+#ifdef KYBER_90S
+
+#include "sha2.h"
+#include "aes256ctr.h"
+
+#if (KYBER_SSBYTES != 32)
+#error "90s variant of Kyber can only generate keys of length 256 bits"
+#endif
+
+typedef aes256ctr_ctx xof_state;
+
+#define XOF_BLOCKBYTES AES256CTR_BLOCKBYTES
+
+#define hash_h(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
+#define hash_g(OUT, IN, INBYTES) sha512(OUT, IN, INBYTES)
+#define xof_absorb(STATE, SEED, X, Y) \
+        aes256ctr_init(STATE, SEED, (X) | ((uint16_t)(Y) << 8))
+#define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) \
+        aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define prf(OUT, OUTBYTES, KEY, NONCE) \
+        aes256ctr_prf(OUT, OUTBYTES, KEY, NONCE)
+#define kdf(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
+
+#else
+
+#include "fips202.h"
+#include "fips202x4.h"
+
+typedef keccak_state xof_state;
+
+#define kyber_shake128_absorb KYBER_NAMESPACE(kyber_shake128_absorb)
+void kyber_shake128_absorb(keccak_state *s,
+                           const uint8_t seed[KYBER_SYMBYTES],
+                           uint8_t x,
+                           uint8_t y);
+
+#define kyber_shake256_prf KYBER_NAMESPACE(kyber_shake256_prf)
+void kyber_shake256_prf(uint8_t *out,
+                        size_t outlen,
+                        const uint8_t key[KYBER_SYMBYTES],
+                        uint8_t nonce);
+
+#define XOF_BLOCKBYTES SHAKE128_RATE
+
+#define hash_h(OUT, IN, INBYTES) sha3_256(OUT, IN, INBYTES)
+#define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
+#define xof_absorb(STATE, SEED, X, Y) kyber_shake128_absorb(STATE, SEED, X, Y)
+#define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) \
+        shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define prf(OUT, OUTBYTES, KEY, NONCE) \
+        kyber_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
+#define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
+
+#endif /* KYBER_90S */
+
+#endif /* SYMMETRIC_H */

--- a/zkpop/kyber/verify.h
+++ b/zkpop/kyber/verify.h
@@ -1,0 +1,14 @@
+#ifndef VERIFY_H
+#define VERIFY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "params.h"
+
+#define verify KYBER_NAMESPACE(verify)
+int verify(const uint8_t *a, const uint8_t *b, size_t len);
+
+#define cmov KYBER_NAMESPACE(cmov)
+void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b);
+
+#endif

--- a/zkpop/kyber/zkpop.h
+++ b/zkpop/kyber/zkpop.h
@@ -1,0 +1,37 @@
+#ifndef ZKPOP__H
+#define ZKPOP__H
+
+#include <stdint.h>
+#include "params.h"
+#include "polyvec.h"
+
+#define LAZY 9
+
+typedef ALIGNED_INT16(ZKPOP_M) bundle_t;
+typedef ALIGNED_INT16(ZKPOP_M-ZKPOP_SIGMA) open_bundle_t;
+
+#if ZKPOP_N > 65536
+#error "Too many parties."
+#elif ZKPOP_N > 256
+typedef uint16_t party_t;
+#else 
+typedef uint8_t party_t;
+#endif
+
+#define crypto_kem_keypair_nizkpop KYBER_NAMESPACE(crypto_kem_keypair_nizkpop)
+int crypto_kem_keypair_nizkpop(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+                    uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES],
+                    uint8_t **zkpop,
+                    size_t *zkpop_size);
+
+#define crypto_nizkpop_verify KYBER_NAMESPACE(crypto_nizkpop_verify)
+int crypto_nizkpop_verify(const unsigned char *pk, const unsigned char *zkpop, unsigned long zkpop_size);
+
+
+void generate_S_E(polyvec *S, polyvec *E, const bundle_t *vk, const uint8_t audit_bundles[(ZKPOP_M+7)/8]);
+void generate_S_E_openbundle(polyvec *S, polyvec *E, open_bundle_t *openbundle, const bundle_t *vk, const uint8_t audit_bundles[(ZKPOP_M+7)/8]);
+void generate_seeds(uint8_t *seedtree);
+void sample_audit_parties (party_t audit_parties[ZKPOP_TAU], const uint8_t hB[KYBER_SYMBYTES]);
+void sample_audit_bundles (uint8_t audit_bundles[(ZKPOP_M+7)/8], const uint8_t h[KYBER_SYMBYTES]);
+
+#endif

--- a/zkpop/kyberKEM.go
+++ b/zkpop/kyberKEM.go
@@ -1,0 +1,69 @@
+// Kyber original bindings, just for comparison purposes
+package zkpop
+
+/*
+#include "kyber/api_kyber.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <openssl/evp.h> //from OpenSSL 1.1.1
+#include <openssl/aes.h>
+*/
+import "C"
+
+import (
+        "fmt"
+        "unsafe"
+)
+
+//binding for pqcrystals_kyber512_avx2_keypair (might need to change to 'ref' instead of avx2.)
+func KeyPairKyber512()([]byte, []byte, error){
+        pk := make([]byte, C.pqcrystals_kyber512_PUBLICKEYBYTES)
+        sk := make([]byte, C.pqcrystals_kyber512_SECRETKEYBYTES)
+
+        ret := C.pqcrystals_kyber512_avx2_keypair((*C.uint8_t)(unsafe.Pointer(&pk[0])),
+                (*C.uint8_t)(unsafe.Pointer(&sk[0])))
+
+        if ret != 0 {
+                return nil, nil, fmt.Errorf("failed to generate keypair")
+        }
+        return pk, sk, nil
+}
+
+
+//Encapsulation for a given public key pk
+//Returns a ciphertext ct and a 16-byte shared secret ss
+func EncapsKyber512(pk []byte)([]byte, []byte, error){
+//      crypto_kem_enc_Frodo640
+//      (unsigned char *ct, unsigned char *ss, const unsigned char *pk)
+        ss := make([]byte, C.pqcrystals_kyber512_BYTES)
+        ct := make([]byte, C.pqcrystals_kyber512_CIPHERTEXTBYTES)
+
+        ret := C.pqcrystals_kyber512_avx2_enc((*C.uint8_t)(unsafe.Pointer(&ct[0])),
+                                           (*C.uint8_t)(unsafe.Pointer(&ss[0])),
+                                           (*C.uint8_t)(unsafe.Pointer(&pk[0])))
+        if ret != 0 {
+                return nil, nil, fmt.Errorf("failed to encaps")
+        }
+        return ct, ss, nil
+}
+
+
+//Given a ciphertext ct and a private key sk
+//returns a candidate shared secret css
+func DecapsKyber512(ct []byte, sk []byte)([]byte, error){
+        css := make([]byte, C.pqcrystals_kyber512_BYTES)
+
+        ret := C.pqcrystals_kyber512_avx2_dec((*C.uint8_t)(unsafe.Pointer(&css[0])),
+                                           (*C.uint8_t)(unsafe.Pointer(&ct[0])),
+                                           (*C.uint8_t)(unsafe.Pointer(&sk[0])))
+        if ret != 0 {
+                return nil, fmt.Errorf("failed to perform decapsulation")
+        }
+        return css, nil
+}
+
+
+
+
+
+

--- a/zkpop/zkpop.go
+++ b/zkpop/zkpop.go
@@ -48,7 +48,7 @@ func VerifyFrodo640ZKPop(pk []byte, zkpop []byte) bool {
 }
 
 //Kyber512-Keypair with NIZKPoP /tmp/go-build/zkpop.cgo2.c:58:(.text+0x23): undefined reference to `pqcrystals_kyber512_avx2_crypto_kem_keypair_nizkpop'
-/*func KeyPairKyber512NIZKPoP()([]byte, []byte, []byte, error){
+func KeyPairKyber512NIZKPoP()([]byte, []byte, []byte, error){
 	//fmt.Println(C.CRYPTO_KALGNAME)
 	pk := make([]byte, C.pqcrystals_kyber512_PUBLICKEYBYTES) //from kyber/api_kyber.h; maybe get from the namespace?
         sk := make([]byte, C.pqcrystals_kyber512_SECRETKEYBYTES)
@@ -69,4 +69,13 @@ func VerifyFrodo640ZKPop(pk []byte, zkpop []byte) bool {
         return pk, sk, zkpopGo, nil
 
 }
-*/
+
+func VerifyKyber512ZKPop(pk []byte, zkpop []byte) bool {
+        ret := C.crypto_nizkpop_verify((*C.uchar)(unsafe.Pointer(&pk[0])),
+                (*C.uchar)(unsafe.Pointer(&zkpop[0])),
+                C.ulong(len(zkpop))) //we could set a 'CRYPTO_NIZKPOPBYTES' in the .h API file...
+        return ret == 0
+}
+
+
+

--- a/zkpop/zkpop.go
+++ b/zkpop/zkpop.go
@@ -3,6 +3,8 @@ package zkpop
 
 /*
 #include "api_frodo640.h"
+#include "kyber/api_kyber.h"
+#include "kyber/api_kyber_zkpop.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <openssl/evp.h> //from OpenSSL 1.1.1
@@ -45,5 +47,26 @@ func VerifyFrodo640ZKPop(pk []byte, zkpop []byte) bool {
         return ret == 0
 }
 
+//Kyber512-Keypair with NIZKPoP /tmp/go-build/zkpop.cgo2.c:58:(.text+0x23): undefined reference to `pqcrystals_kyber512_avx2_crypto_kem_keypair_nizkpop'
+/*func KeyPairKyber512NIZKPoP()([]byte, []byte, []byte, error){
+	//fmt.Println(C.CRYPTO_KALGNAME)
+	pk := make([]byte, C.pqcrystals_kyber512_PUBLICKEYBYTES) //from kyber/api_kyber.h; maybe get from the namespace?
+        sk := make([]byte, C.pqcrystals_kyber512_SECRETKEYBYTES)
+        var zkpop *C.uint8_t
+        var zkpopSize C.size_t
 
+        ret := C.crypto_kem_keypair_nizkpop((*C.uint8_t)(unsafe.Pointer(&pk[0])),
+                (*C.uint8_t)(unsafe.Pointer(&sk[0])),
+                &zkpop, &zkpopSize)
 
+        if ret != 0 {
+                return nil, nil, nil, fmt.Errorf("failed to generate keypair")
+        }
+
+        zkpopGo := C.GoBytes(unsafe.Pointer(zkpop), C.int(zkpopSize))
+        C.free(unsafe.Pointer(zkpop)) // Free zkpop allocated in C
+
+        return pk, sk, zkpopGo, nil
+
+}
+*/


### PR DESCRIPTION
- Adds support for Kyber-512 keypair, encaps, decaps, keypair-with-zkpop and verify zkpop.
- You'll need to build as specified in the README and update the path inside `main.go`.
- Note that the implementation focuses on the Kyber-avx2 version.